### PR TITLE
removed double paper on array icons

### DIFF
--- a/src/gestures.js
+++ b/src/gestures.js
@@ -1,7 +1,7 @@
 const { GestureDescription, Finger, FingerCurl, FingerDirection } = window.fp;
 
 const icons = [
-  'thumbs_up', 'thumbs_down', 'rock', 'paper', 'paper', 'scissors', 'middle', 'fazol', 'ok', 'pinching',
+  'thumbs_up', 'thumbs_down', 'rock', 'paper', 'scissors', 'middle', 'fazol', 'ok', 'pinching',
   'painLeft', 'top', 'show', 'yes', 'horn', 'rightHand'
 ]
 


### PR DESCRIPTION
# FIX DESCRIPTION

### This fix it's just for remove de duplicated instance of 'paper' on the array of icons

Analyzing the code of the last PR, I noticed that I missed a duplicate item in the array, this PR will remove it.